### PR TITLE
Removes parenthesis around replaced params

### DIFF
--- a/lib/params-applier/rules-applier.js
+++ b/lib/params-applier/rules-applier.js
@@ -6,6 +6,17 @@ export default (path = '', rules = []) => {
 		rules
 			.map(rule => applyRule(path, rule))
 			.reduce((result, item) => result.concat(item), [])
+			.map(location => {
+				// for each remaining (optional) param group that hasn't been removed, the optional group is removed from the location
+				// /foo/bar(/:param) => /foo/bar
+				location = location.replace(/\((.*:.*)\)/g, '');
+
+				// remove other parenthesis that might be wrapping params that have been replaced
+				// /foo(/:bar) => /foo(/bar-value) => /foo/bar-value
+				location = location.replace(/(\(|\))/g, '');
+
+				return location;
+			})
 	);
 
 };

--- a/test/spec/params-applier/rules-applier.spec.js
+++ b/test/spec/params-applier/rules-applier.spec.js
@@ -19,4 +19,36 @@ describe('rules applier', () => {
 
 	});
 
+	it('replaces optional params in path by list rules', () => {
+
+		const path = '/path/:param-one(/:param-two)';
+		const rules = [
+			{ 'param-one': 1 },
+			{ 'param-one': 1, 'param-two': 2 },
+		];
+		const etalon = [
+			'/path/1',
+			'/path/1/2',
+		];
+
+		expect(applyRules(path, rules)).toHaveSameItems(etalon, true);
+
+	});
+
+	it('removes optional params in path by list rules whose value hasn\'t been provided', () => {
+
+		const path = '/path/:param-one(/:param-two)';
+		const rules = [
+			{},
+			{ 'param-one': 1 },
+		];
+		const etalon = [
+			'/path/:param-one',
+			'/path/1',
+		];
+
+		expect(applyRules(path, rules)).toHaveSameItems(etalon, true);
+
+	});
+
 });


### PR DESCRIPTION
Fixes https://github.com/kuflash/react-router-sitemap/issues/43
Old:
```
/route(/:param) {param: 'value'} => /route(/value)
/route(/:param) {} => /route(/:param)
```

With fix:
```
/route(/:param) {param: 'value'} => /route/value
/route(/param) {} => /route
```

LMK if you'd like me to add tests or stuff :)