### PR TITLE
Add independent createRoutes method to support v4 react-router

### DIFF
--- a/api.md
+++ b/api.md
@@ -36,12 +36,12 @@ Filter paths using the specified rules.
 
 **Parameters**
 
--   `filterConfig` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Filter configuration
+-   `filterConfig` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Filter configuration
 
 **Properties**
 
--   `rules` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)>** List filter rules.
--   `isValid` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Flag that defines a way to filter paths.
+-   `rules` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[RegExp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)>** List filter rules.
+-   `isValid` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Flag that defines a way to filter paths.
     If `true`, the path satisfying the rules will be included.
     If `false`, the path satisfying the rules will be excluded.
 
@@ -65,7 +65,7 @@ Replace the dynamic parameters in paths using the given values.
 
 **Parameters**
 
--   `paramsConfig` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)>** Configuration for replacing params.
+-   `paramsConfig` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)>** Configuration for replacing params.
 
 **Examples**
 
@@ -96,8 +96,8 @@ Convert array of paths to sitemap.
 
 **Parameters**
 
--   `hostname` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The root name of your site.
--   `$1` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**  (optional, default `{}`)
+-   `hostname` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The root name of your site.
+-   `$1` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**  (optional, default `{}`)
     -   `$1.limitCountPaths`   (optional, default `49999`)
 
 ## save
@@ -106,8 +106,8 @@ Save sitemaps and sitemap index in files.
 
 **Parameters**
 
--   `dist` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The path and file name where the sitemap index is saved.
--   `publicPath` **\[[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)](default '/')** optional public path relative to hostname, default: '/'
+-   `dist` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The path and file name where the sitemap index is saved.
+-   `publicPath` **\[[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)](default '/')** optional public path relative to hostname, default: '/'
 
 # pathsSplitter
 
@@ -115,8 +115,8 @@ Module for splitting paths array in multiple arrays for support of large project
 
 **Parameters**
 
--   `paths` **\[[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)]** Initial paths array (flattened) (optional, default `[]`)
--   `size` **\[[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]**  (optional, default `49999`)
+-   `paths` **\[[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)]** Initial paths array (flattened) (optional, default `[]`)
+-   `size` **\[[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)]**  (optional, default `49999`)
 
 **Examples**
 
@@ -132,8 +132,8 @@ Module for applying params in dynamic paths.
 
 **Parameters**
 
--   `paths` **\[[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>]** Array of paths
--   `paramsConfig` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)>]** Configuration matching parameters and values
+-   `paths` **\[[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>]** Array of paths
+-   `paramsConfig` **\[[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)>]** Configuration matching parameters and values
 
 **Examples**
 
@@ -167,7 +167,7 @@ const paths = applyParams(paths, config);
 // ['/path/a/1', '/path/b/2', '/path/b/3']
 ```
 
-Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** Array of paths
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** Array of paths
 
 # pathsFilter
 
@@ -175,9 +175,9 @@ Module for filtering an array of paths.
 
 **Parameters**
 
--   `paths` **\[[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>]** Array of paths
--   `rules` **\[[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)>]** Filter rules
--   `isValidRules` **\[[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** Flag that defines a way to filter paths.
+-   `paths` **\[[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>]** Array of paths
+-   `rules` **\[[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[RegExp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)>]** Filter rules
+-   `isValidRules` **\[[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** Flag that defines a way to filter paths.
     If `true`, the path satisfying the rules will be included.
     If `false`, the path satisfying the rules will be excluded.
 
@@ -205,23 +205,43 @@ const paths = filterPaths(paths, rules, isValidRules);
 // ['/auth']
 ```
 
-Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** Array of paths.
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** Array of paths.
 
-# routesParser
+# createRoutes
 
-Module for parsing the result of the `createRoutes(<Route>)` function.
-from [react-router](https://www.npmjs.com/package/react-router) package.
+Creates and returns an array of routes from the given object which
+may be a JSX route, a plain object route, or an array of either.
 
 **Parameters**
 
--   `routes` **\[([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) \| [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object))]** Result of execute function
-    `createRoutes(<Route>)` (optional, default `[]`)
--   `basePath` **\[[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** Prefix for all paths (optional, default `''`)
+-   `routes` **Route** React Router configuration.
 
 **Examples**
 
 ```javascript
-import { createRoutes } from 'react-router';
+import { routesCreater as createRoutes } from 'react-router-sitemap';
+import { routesParser as parseRoutes } from 'react-router-sitemap';
+
+const routes = createRoutes(<Route path='/home'>);
+const paths = parseRoutes(routes); // ['/home']
+```
+
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
+
+# routesParser
+
+Module for parsing the result of the `createRoutes(<Route>)` function.
+
+**Parameters**
+
+-   `routes` **\[([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array) \| [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object))]** Result of execute function
+    `createRoutes(<Route>)` (optional, default `[]`)
+-   `basePath` **\[[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)]** Prefix for all paths (optional, default `''`)
+
+**Examples**
+
+```javascript
+import { routesCreater as createRoutes } from 'react-router-sitemap';
 import { routesParser as parseRoutes } from 'react-router-sitemap';
 
 const routes = createRoutes(<Route path='/home'>);
@@ -229,7 +249,7 @@ const paths = parseRoutes(routes); // ['/home']
 ```
 
 ```javascript
-import { createRoutes } from 'react-router';
+import { routesCreater as createRoutes } from 'react-router-sitemap';
 import { routesParser as parseRoutes } from 'react-router-sitemap';
 
 const routes = createRoutes(<Route path='/home'>);
@@ -237,7 +257,7 @@ const prefix = '/prefix';
 const paths = parseRoutes(routes, prefix); // ['/prefix/home']
 ```
 
-Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** Array of paths
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** Array of paths
 
 # sitemapBuilder
 
@@ -245,8 +265,8 @@ Module for building a sitemap using an array of paths. Uses the [sitemap](https:
 
 **Parameters**
 
--   `hostname` **\[[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** The root name of your site
--   `paths` **\[[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>]** Array of paths
+-   `hostname` **\[[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)]** The root name of your site
+-   `paths` **\[[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>]** Array of paths
 
 **Examples**
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,8 @@ import fs from 'fs';
 import path from 'path';
 
 import sm from 'sitemap';
-import { createRoutes } from 'react-router';
 
+import createRoutes from './routes-creater';
 import parseRoutes from './routes-parser';
 import filterPaths from './paths-filter';
 import applyParams from './params-applier';
@@ -158,6 +158,7 @@ class Sitemap {
 
 export default Sitemap;
 
+export { default as routesCreater } from './routes-creater';
 export { default as routesParser } from './routes-parser';
 export { default as pathsFilter } from './paths-filter';
 export { default as paramsApplier } from './params-applier';

--- a/lib/routes-creater/index.js
+++ b/lib/routes-creater/index.js
@@ -1,80 +1,26 @@
-function isValidChild(object) {
-    return object == null || React.isValidElement(object);
-}
-
-export function isReactChildren(object) {
-    return isValidChild(object) || (Array.isArray(object) && object.every(isValidChild))
-}
-
-function createRoute(defaultProps, props) {
-    return { ...defaultProps,
-        ...props
-    }
-}
-
-export function createRouteFromReactElement(element) {
-    const type = element.type
-    const route = createRoute(type.defaultProps, element.props)
-
-    if (route.children) {
-        const childRoutes = createRoutesFromReactChildren(route.children, route)
-
-        if (childRoutes.length)
-            route.childRoutes = childRoutes
-
-        delete route.children
-    }
-
-    return route
-}
+import { isReactChildren, createRoutesFromReactChildren } from './routeUtils';
 
 /**
- * Creates and returns a routes object from the given ReactChildren. JSX
- * provides a convenient way to visualize how routes in the hierarchy are
- * nested.
- *
- *   import { Route, createRoutesFromReactChildren } from 'react-router'
- *
- *   const routes = createRoutesFromReactChildren(
- *     <Route component={App}>
- *       <Route path="home" component={Dashboard}/>
- *       <Route path="news" component={NewsFeed}/>
- *     </Route>
- *   )
- *
- * Note: This method is automatically used when you provide <Route> children
- * to a <Router> component.
- */
-export function createRoutesFromReactChildren(children, parentRoute) {
-    const routes = []
-
-    React.Children.forEach(children, function (element) {
-        if (React.isValidElement(element)) {
-            // Component classes may have a static create* method.
-            if (element.type.createRouteFromReactElement) {
-                const route = element.type.createRouteFromReactElement(element, parentRoute)
-
-                if (route)
-                    routes.push(route)
-            } else {
-                routes.push(createRouteFromReactElement(element))
-            }
-        }
-    })
-
-    return routes
-}
-
-/**
- * Creates and returns an array of routes from the given object which
+ * @description Creates and returns an array of routes from the given object which
  * may be a JSX route, a plain object route, or an array of either.
+ * @param {Route} routes - React Router configuration.
+ * @return {Array<String>}
+ *
+ * @example
+ * import { routesCreater as createRoutes } from 'react-router-sitemap';
+ * import { routesParser as parseRoutes } from 'react-router-sitemap';
+ *
+ * const routes = createRoutes(<Route path='/home'>);
+ * const paths = parseRoutes(routes); // ['/home']
  */
-export function createRoutes(routes) {
-    if (isReactChildren(routes)) {
-        routes = createRoutesFromReactChildren(routes)
-    } else if (routes && !Array.isArray(routes)) {
-        routes = [routes]
-    }
+const createRoutes = routes => {
+	if (isReactChildren(routes)) {
+		routes = createRoutesFromReactChildren(routes);
+	} else if (routes && !Array.isArray(routes)) {
+		routes = [routes];
+	}
 
-    return routes
-}
+	return routes;
+};
+
+export default createRoutes;

--- a/lib/routes-creater/index.js
+++ b/lib/routes-creater/index.js
@@ -1,0 +1,80 @@
+function isValidChild(object) {
+    return object == null || React.isValidElement(object);
+}
+
+export function isReactChildren(object) {
+    return isValidChild(object) || (Array.isArray(object) && object.every(isValidChild))
+}
+
+function createRoute(defaultProps, props) {
+    return { ...defaultProps,
+        ...props
+    }
+}
+
+export function createRouteFromReactElement(element) {
+    const type = element.type
+    const route = createRoute(type.defaultProps, element.props)
+
+    if (route.children) {
+        const childRoutes = createRoutesFromReactChildren(route.children, route)
+
+        if (childRoutes.length)
+            route.childRoutes = childRoutes
+
+        delete route.children
+    }
+
+    return route
+}
+
+/**
+ * Creates and returns a routes object from the given ReactChildren. JSX
+ * provides a convenient way to visualize how routes in the hierarchy are
+ * nested.
+ *
+ *   import { Route, createRoutesFromReactChildren } from 'react-router'
+ *
+ *   const routes = createRoutesFromReactChildren(
+ *     <Route component={App}>
+ *       <Route path="home" component={Dashboard}/>
+ *       <Route path="news" component={NewsFeed}/>
+ *     </Route>
+ *   )
+ *
+ * Note: This method is automatically used when you provide <Route> children
+ * to a <Router> component.
+ */
+export function createRoutesFromReactChildren(children, parentRoute) {
+    const routes = []
+
+    React.Children.forEach(children, function (element) {
+        if (React.isValidElement(element)) {
+            // Component classes may have a static create* method.
+            if (element.type.createRouteFromReactElement) {
+                const route = element.type.createRouteFromReactElement(element, parentRoute)
+
+                if (route)
+                    routes.push(route)
+            } else {
+                routes.push(createRouteFromReactElement(element))
+            }
+        }
+    })
+
+    return routes
+}
+
+/**
+ * Creates and returns an array of routes from the given object which
+ * may be a JSX route, a plain object route, or an array of either.
+ */
+export function createRoutes(routes) {
+    if (isReactChildren(routes)) {
+        routes = createRoutesFromReactChildren(routes)
+    } else if (routes && !Array.isArray(routes)) {
+        routes = [routes]
+    }
+
+    return routes
+}

--- a/lib/routes-creater/routeUtils.js
+++ b/lib/routes-creater/routeUtils.js
@@ -1,0 +1,76 @@
+import React from 'react';
+
+/**
+ * @description Use React method to test if is a valid React Element.
+ * @param {Object} object - Which to test if is valid React Element.
+ * @return {Boolean}
+ * @ignore
+ */
+const isValidChild = object => {
+	return object === null || React.isValidElement(object);
+};
+
+/**
+ * @param {Object|array}
+ * @return {Boolean}
+ * @ignore
+ */
+const isReactChildren = object => {
+	return isValidChild(object) || (Array.isArray(object) && object.every(isValidChild));
+};
+
+/**
+ * @description Creates and returns a routes object from the given ReactChildren. JSX
+ * provides a convenient way to visualize how routes in the hierarchy are
+ * nested.
+ * @param {ReactChildren} children - ReactChildren in JSX
+ * @return {Object} routes object
+ * @ignore
+ */
+const createRoutesFromReactChildren = children => {
+	const routes = [];
+
+	/**
+	 * @param {Object} element - ReactChild
+	 * @return {Object} route object
+	 * @ignore
+	 */
+	const createRouteFromReactElement = element => {
+		const type = element.type;
+		const route = Object.assign({}, type.defaultProps, element.props);
+
+		if (route.children) {
+			const childRoutes = createRoutesFromReactChildren(route.children, route);
+
+			if (childRoutes.length) {
+				route.childRoutes = childRoutes;
+			}
+			delete route.children;
+		}
+
+		return route;
+	};
+
+	React.Children.forEach(children, function (element) {
+		if (React.isValidElement(element)) {
+			// Component classes may have a static create* method.
+			if (element.type.createRouteFromReactElement) {
+				const route = element.type.createRouteFromReactElement(element);
+
+				if (route) {
+					routes.push(route);
+				}
+			} else {
+				routes.push(createRouteFromReactElement(element));
+			}
+		}
+	});
+
+	return routes;
+};
+
+export {
+	isValidChild,
+	isReactChildren,
+	createRoutesFromReactChildren
+};

--- a/lib/routes-parser/index.js
+++ b/lib/routes-parser/index.js
@@ -2,7 +2,6 @@ import buildPath from './path-builder';
 
 /**
  * Module for parsing the result of the `createRoutes(<Route>)` function.
- * from [react-router](https://www.npmjs.com/package/react-router) package.
  * @module routesParser
  * @param {Array|Object} [routes = []] Result of execute function
  * `createRoutes(<Route>)`
@@ -10,14 +9,14 @@ import buildPath from './path-builder';
  * @return {Array<String>} Array of paths
  *
  * @example
- * import { createRoutes } from 'react-router';
+ * import { routesCreater as createRoutes } from 'react-router-sitemap';
  * import { routesParser as parseRoutes } from 'react-router-sitemap';
  *
  * const routes = createRoutes(<Route path='/home'>);
  * const paths = parseRoutes(routes); // ['/home']
  *
  * @example
- * import { createRoutes } from 'react-router';
+ * import { routesCreater as createRoutes } from 'react-router-sitemap';
  * import { routesParser as parseRoutes } from 'react-router-sitemap';
  *
  * const routes = createRoutes(<Route path='/home'>);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "karma start ./config/karma.config.js",
     "build": "npm run lint && npm run test && webpack --config ./config/build.config.js",
     "example": "cd example && node ./sitemap-builder.js",
-    "documentation": "documentation build ./lib ./lib/routes-parser ./lib/paths-filter ./lib/params-applier ./lib/sitemap-builder -f md > api.md",
+    "documentation": "documentation build ./lib ./lib/routes-creater ./lib/routes-parser ./lib/paths-filter ./lib/params-applier ./lib/sitemap-builder -f md > api.md",
     "prepublish": "npm run build"
   },
   "author": "Igor Uvarov <kuflash@ya.ru> (http://kuflash.ru)",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "react": "^15.1.0 || ^16.0.0",
-    "react-router": "^2.3.0 || ^3.2.1"
+    "react-router": "^2.3.0 || ^3.2.1 || ^4.3.0"
   },
   "dependencies": {
     "sitemap": "^1.6.0"

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,23 @@ export default (
 	</Route>
 );
 ```
+If you are using v4 `react-router`, your `router.jsx` might be:
+```js
+import React from 'react';
+import { Switch, Route } from 'react-router';
+
+export default (
+	// Switch is added in v4 react-router
+	<Switch>
+		<Route path='/' />
+		<Route path='/about' />
+		<Route path='/projects' />
+		<Route path='/contacts' />
+		<Route path='/auth' />
+		<Route /> // No-match case
+	</Switch>
+);
+```
 And you need to create a script which will run from the command line or on the server.
 
 _Please note that in this case you need a module 'babel-register' to work with the ES2105 syntax and `.jsx` format._


### PR DESCRIPTION
Borrow `createRoutes` function from v3 react-router code base and make it as a internal function. This fixes the missing `createRoutes` method issue which caused by complete rewrite of v4 react-router.